### PR TITLE
Add account

### DIFF
--- a/pgpool.py
+++ b/pgpool.py
@@ -167,7 +167,7 @@ def account_add():
     try:
         data = json.loads(request.data)
     except:
-        abort(400)
+        return 'Data not properly json formatted!', 400
 
     if isinstance(data, list):
         for acc in data:

--- a/pgpool.py
+++ b/pgpool.py
@@ -216,10 +216,10 @@ def account_add():
         else:
             add_account(accounts)
     else:
-        page = """"<form method=POST>
+        page = """<form method=POST>
                    <table>
                    <tr>
-                   <td style='padding: 10px'>Level: <input type='number' name='level' min='0' max='40' size=3></td>
+                   <td style='padding: 10px'>Level: <input type='number' name='level' min='0' max='40' style='width: 4em'></td>
                    <td>Condition: 
                    <select name='condition'>
                         <option value='unknown'></option>


### PR DESCRIPTION
Creates an http endpoint `/account/add` that will accept POST requests to add accounts. Request takes three arguments:

`accounts`: csv formatted argument with account information on each line
`level`: force level of all accounts to this value, defaults to 1
`condition`: force condition of accounts, defaults to unknown, other values 'good', 'banned', 'blind', 'captcha'

If a GET request is made then a form template will be displayed for adding accounts.

This has been tested adding about a 1000 new accounts. The webpage may error out, but the accounts were successfully added. May handle account adding in a separate thread at a future time.