### PR TITLE
Webhooks

### DIFF
--- a/pgpool.py
+++ b/pgpool.py
@@ -8,10 +8,11 @@ from werkzeug.exceptions import abort
 
 from pgpool.config import cfg_get
 from pgpool.console import print_status, stats_conditions
-from pgpool.models import init_database, db_updater, Account, auto_release, flaskDb
+from pgpool.models import init_database, db_updater, Account, auto_release, flaskDb, set_webhook_queue
 
 # ---------------------------------------------------------------------------
 from pgpool.utils import parse_bool, rss_mem_size
+from pgpool.webhook import wh_updater, load_filters
 
 logging.basicConfig(level=logging.INFO,
     format='%(asctime)s [%(threadName)16s][%(module)14s][%(levelname)8s] %(message)s')
@@ -128,6 +129,25 @@ def run_server():
 # ---------------------------------------------------------------------------
 
 log.info("PGPool starting up...")
+
+# WH updates queue
+wh_updates_queue = None
+if not cfg_get('wh_filter'):
+    log.info('Webhook disabled.')
+else:
+    log.info('Webhook enabled for events; loading filters from %s',
+             cfg_get('wh_filter'))
+    if not load_filters(cfg_get('wh_filter')):
+        log.warning("Unable to load webhook filters from {}. Exiting...".format(cfg_get('wh_filter')))
+        raise SystemExit
+    wh_updates_queue = Queue()
+    set_webhook_queue(wh_updates_queue)
+    # Thread to process webhook updates.
+    for i in range(cfg_get('wh_threads')):
+        log.debug('Starting wh-updater worker thread %d', i)
+        t = Thread(target=wh_updater, name='wh-updater-{}'.format(i), args=(wh_updates_queue,))
+        t.daemon = True
+        t.start()
 
 db = init_database(app)
 

--- a/pgpool/config.py
+++ b/pgpool/config.py
@@ -18,7 +18,9 @@ cfg = {
     'db_max_connections': 20,
     'log_updates': True,
     'account_release_timeout': 120,     # Accounts are being released automatically after this many minutes from last update
-    'max_queue_size': 50                # Block update requests if queue already has this many items
+    'max_queue_size': 50,                # Block update requests if queue already has this many items
+    'wh_filter': '',
+    'wh_threads': 1
 }
 
 

--- a/pgpool/models.py
+++ b/pgpool/models.py
@@ -20,7 +20,9 @@ flaskDb = FlaskDB()
 
 request_lock = Lock()
 
-db_schema_version = 2
+db_schema_version = 3
+
+webhook_queue = None
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
     pass
@@ -48,6 +50,7 @@ class Account(flaskDb.Model):
     email = Utf8mb4CharField(null=True)
     last_modified = DateTimeField(index=True, default=datetime.now)
     system_id = Utf8mb4CharField(max_length=64, index=True, null=True)  # system which uses the account
+    assigned_at = DateTimeField(index=True, null=True)
     latitude = DoubleField(null=True)
     longitude = DoubleField(null=True)
     # from player_stats
@@ -125,10 +128,15 @@ class Account(flaskDb.Model):
                     old_system_id = account.system_id
                     account.system_id = system_id
                     account.last_modified = datetime.now()
-                    account.save()
 
                     if old_system_id != system_id:
+                        account.assigned_at = datetime.now()
                         new_account_event(account, "Got assigned to [{}]".format(system_id))
+                        if webhook_queue:
+                            webhook_queue.put(('assign', create_webhook_data('assigned', None, account,
+                                                                               "Got assigned to [{}]".format(system_id))))
+
+                    account.save()
 
                     count -= 1
 
@@ -223,6 +231,12 @@ def migrate_database(db, old_ver):
             migrator.rename_column('event', 'type', 'entity_type')
         )
 
+    if old_ver < 3:
+        migrate(
+            migrator.add_column('account', 'assigned_at',
+                                DateTimeField(index=True, null=True))
+        )
+
     Version.update(val=db_schema_version).where(
         Version.key == 'schema_version').execute()
     log.info("Done migrating database.")
@@ -285,39 +299,73 @@ def new_account_event(acc, description):
 
 
 def eval_acc_state_changes(acc_prev, acc_curr, metadata):
+
     level_prev = acc_prev.level
     level_curr = acc_curr.level
     if level_prev is not None and level_curr is not None and level_prev < level_curr:
         new_account_event(acc_curr, "Level {} reached".format(level_curr))
+        if webhook_queue:
+            webhook_queue.put(('levelup', create_webhook_data('levelup', acc_prev.system_id, acc_curr,
+                                                             "Level {} reached".format(level_curr))))
 
     got_true = cmp_bool(acc_prev.warn, acc_curr.warn)
-    if got_true is not None:
-        new_account_event(acc_curr, "Got warn flag :-/") if got_true else new_account_event(acc_curr,
-                                                                                            "Warn flag lifted :-)")
+    if got_true:
+        new_account_event(acc_curr, "Got warn flag :-/")
+        if webhook_queue:
+            webhook_queue.put(('warn', create_webhook_data('warn', acc_prev.system_id, acc_curr, "Got warn flag :-/")))
+    elif got_true is False:
+        new_account_event(acc_curr, "Warn flag lifted :-)")
+        if webhook_queue:
+            webhook_queue.put(('warn', create_webhook_data('warn', acc_prev.system_id, acc_curr, "Warn flag lifted :-)")))
 
     got_true = cmp_bool(acc_prev.shadowbanned, acc_curr.shadowbanned)
-    if got_true is not None:
-        new_account_event(acc_curr, "Got shadowban flag :-(") if got_true else new_account_event(acc_curr,
-                                                                                                 "Shadowban flag lifted :-)")
+    if got_true:
+        new_account_event(acc_curr, "Got shadowban flag :-(")
+        if webhook_queue:
+            webhook_queue.put(('shadowban', create_webhook_data('shadowban', acc_prev.system_id, acc_curr, "Got shadowban flag :-(")))
+    elif got_true is False:
+        new_account_event(acc_curr, "Shadowban flag lifted :-)")
+        if webhook_queue:
+            webhook_queue.put(('shadowban', create_webhook_data('shadowban', acc_prev.system_id, acc_curr, "Shadowban flag lifted :-)")))
 
     got_true = cmp_bool(acc_prev.banned, acc_curr.banned)
     if got_true is not None:
-        new_account_event(acc_curr, "Got banned :-(((") if got_true else new_account_event(acc_curr, "Ban lifted :-)))")
+        new_account_event(acc_curr, "Got banned :-(((")
+        if webhook_queue:
+            webhook_queue.put(('ban', create_webhook_data('ban', acc_prev.system_id, acc_curr, "Got banned :-(((")))
+    elif got_true is False:
+        new_account_event(acc_curr, "Ban lifted :-)))")
+        if webhook_queue:
+            webhook_queue.put(('ban', create_webhook_data('ban', acc_prev.system_id, acc_curr, "Ban lifted :-)))")))
 
     got_true = cmp_bool(acc_prev.ban_flag, acc_curr.ban_flag)
-    if got_true is not None:
-        new_account_event(acc_curr, "Got ban flag :-X") if got_true else new_account_event(acc_curr,
-                                                                                           "Ban flag lifted :-O")
+    if got_true:
+        new_account_event(acc_curr, "Got ban flag :-X")
+        if webhook_queue:
+            webhook_queue.put(('banflag', create_webhook_data('banflag', acc_prev.system_id, acc_curr, "Got ban flag :-X")))
+    elif got_true is False:
+        new_account_event(acc_curr, "Ban flag lifted :-O")
+        if webhook_queue:
+            webhook_queue.put(('banflag', create_webhook_data('banflag', acc_prev.system_id, acc_curr, "Ban flag lifted :-O")))
 
     got_true = cmp_bool(acc_prev.captcha, acc_curr.captcha)
-    if got_true is not None:
-        new_account_event(acc_curr, "Got CAPTCHA'd :-|") if got_true else new_account_event(acc_curr,
-                                                                                            "CAPTCHA solved :-)")
+    if got_true:
+        new_account_event(acc_curr, "Got CAPTCHA'd :-|")
+        if webhook_queue:
+            webhook_queue.put(('captcha', create_webhook_data('captcha', acc_prev.system_id, acc_curr, "Got CAPTCHA'd :-|")))
+    elif got_true is False:
+        new_account_event(acc_curr, "CAPTCHA solved :-)")
+        if webhook_queue:
+            webhook_queue.put(('captcha', create_webhook_data('captcha', acc_prev.system_id, acc_curr, "CAPTCHA solved :-)")))
 
     if acc_prev.system_id is not None and acc_curr.system_id is None:
         new_account_event(acc_curr, "Got released from [{}]: {}".format(acc_prev.system_id,
                                                                         metadata.get('_release_reason',
                                                                                      'unknown reason')))
+        if webhook_queue:
+            webhook_queue.put(('release', create_webhook_data('release', acc_prev.system_id, acc_curr,
+                                                            metadata.get('_release_reason', 'unknown reason'))))
+
 
         # if acc_prev.rareless_scans == 0 and acc_curr.rareless_scans > 0:
         #     new_account_event(acc_curr, "Started seeing only commons :-/")
@@ -336,6 +384,8 @@ def update_account(data, db):
                     setattr(acc, key, value)
                 else:
                     metadata[key] = value
+            if acc.system_id and acc.assigned_at is None:
+                acc.assigned_at = datetime.now()        #make sure accounts with a system_id have an assigned time
             acc.last_modified = datetime.now()
             eval_acc_state_changes(acc_previous, acc, metadata)
             acc.save()
@@ -370,7 +420,11 @@ def auto_release():
                                                                                                          release_timeout))
             for acc in accounts:
                 new_account_event(acc, "Auto-releasing from [{}]".format(acc.system_id))
+                if webhook_queue:
+                    webhook_queue.put(('release', create_webhook_data('release', acc.system_id, acc,
+                                                                        "Auto-releasing from [{}]".format(acc.system_id))))
                 acc.system_id = None
+                acc.assigned_at = None
                 acc.last_modified = datetime.now()
                 acc.save()
         except Exception as e:
@@ -390,3 +444,61 @@ def create_tables(db):
         else:
             log.debug('Skipping table %s, it already exists.', table.__name__)
     db.close()
+
+def set_webhook_queue(wh_queue):
+    global webhook_queue
+    webhook_queue = wh_queue
+
+def create_webhook_data(wh_type, prev_sysid, acc_cur, message=""):
+    low, high, unknown, total = query_accounts("banned = 0 and shadowbanned = 0 and captcha = 0")
+    if acc_cur.assigned_at:
+        running_time = (datetime.now() - acc_cur.assigned_at).total_seconds() / 3600.      #Calculate running_time in hours
+    else:
+        running_time = None
+
+    webhook_data = {
+        'type': wh_type,
+        'system_id': acc_cur.system_id if acc_cur.system_id else prev_sysid,
+        'assigned_at': acc_cur.assigned_at,
+        'running_time': "{0:.2f}".format(running_time or 0),
+        'username': acc_cur.username,
+        'auth_service': acc_cur.auth_service,
+        'latitude': acc_cur.latitude,
+        'longitude': acc_cur.longitude,
+        'level': acc_cur.level,
+        'xp': acc_cur.xp,
+        'encounters': acc_cur.encounters,
+        'last_modified': acc_cur.last_modified,
+        'warn': acc_cur.warn,
+        'shadowbanned': acc_cur.shadowbanned,
+        'banned': acc_cur.banned,
+        'ban_flag': acc_cur.ban_flag,
+        'captcha': acc_cur.captcha,
+        'rareless_scans': acc_cur.rareless_scans,
+        'message': message,
+        'good_low_level': low,
+        'good_high_level': high,
+        'good_total': total
+    }
+    return webhook_data
+
+
+#Queries DB for accounts with condition, returns tuple with low (level<30), high(level>=30), unknown, total accounts
+def query_accounts(condition):
+    cursor = flaskDb.database.execute_sql('''
+            select (case when level < 30 then "low" when level >= 30 then "high" else "unknown" end) as category, count(*) from account
+            where {}
+            group by category
+        '''.format(condition))
+    low = 0
+    high = 0
+    unknown = 0
+    for row in cursor.fetchall():
+        if row[0] == 'low':
+            low = row[1]
+        elif row[0] == 'high':
+            high = row[1]
+        elif row[0] == 'unknown':
+            unknown = row[1]
+
+    return low, high, unknown, low + high + unknown

--- a/pgpool/models.py
+++ b/pgpool/models.py
@@ -133,7 +133,7 @@ class Account(flaskDb.Model):
                         account.assigned_at = datetime.now()
                         new_account_event(account, "Got assigned to [{}]".format(system_id))
                         if webhook_queue:
-                            webhook_queue.put(('assign', create_webhook_data('assigned', None, account,
+                            webhook_queue.put(('assign', create_webhook_data('assign', None, account,
                                                                                "Got assigned to [{}]".format(system_id))))
 
                     account.save()

--- a/pgpool/webhook.py
+++ b/pgpool/webhook.py
@@ -229,6 +229,12 @@ class Filter:
         if 'system_id' in self.filter:
             if not data.get('system_id') or data.get('system_id') not in self.filter['system_id']:
                 return False
+        if 'low_lvl_threshold' in self.filter:
+            if data.get('good_low_level', 2^31) > self.filter['low_lvl_threshold']:
+                return False
+        if 'high_lvl_threshold' in self.filter:
+            if data.get('good_high_level', 2^31) > self.filter['high_lvl_threshold']:
+                return False
 
         return True
 
@@ -247,6 +253,10 @@ class Filter:
             return False, "Filter min_lvl must be an integer!"
         if 'max_lvl' in self.filter and not str(self.filter['max_lvl']).isdigit():
             return False, "Filter max_lvl must be an integer!"
+        if 'low_lvl_threshold' in self.filter and not str(self.filter['low_lvl_threshold']).isdigit():
+            return False, "Filter low_lvl_theshold must be an integer!"
+        if 'high_lvl_threshold' in self.filter and not str(self.filter['high_lvl_threshold']).isdigit():
+            return False, "Filter high_lvl_theshold must be an integer!"
         return True, ""
 
     def get_webhook_url(self):

--- a/pgpool/webhook.py
+++ b/pgpool/webhook.py
@@ -1,0 +1,5 @@
+import requests
+import threading
+from queue import Empty
+from cachetools import LFUCache
+

--- a/pgpool/webhook.py
+++ b/pgpool/webhook.py
@@ -1,5 +1,261 @@
+import json
+import logging
+
+import copy
 import requests
 import threading
-from queue import Empty
-from cachetools import LFUCache
+
+from timeit import default_timer
+from Queue import Empty
+# from cachetools import LFUCache
+
+from requests_futures.sessions import FuturesSession
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+from pgpool.config import cfg_get
+
+log = logging.getLogger(__name__)
+
+wh_lock = threading.Lock()
+
+wh_retries = 3
+wh_timeout = 2
+wh_backoff_factor = 0.25
+wh_concurrency = 25
+wh_lfu_size = 1000
+wh_frame_interval = 500
+
+filters = []
+
+
+def send_to_webhooks(session, message_frame):
+
+    req_timeout = wh_timeout
+
+    for hooks in message_frame:
+        try:
+            # Disable keep-alive and set streaming to True, so we can skip
+            # the response content.
+            session.post(hooks.get('webhook'), json=hooks.get('message'),
+                         timeout=(None, req_timeout),
+                         background_callback=__wh_completed,
+                         headers={'Connection': 'close'},
+                         stream=True)
+        except requests.exceptions.ReadTimeout:
+            log.exception('Response timeout on webhook endpoint %s.', hooks.get('webhook'))
+        except requests.exceptions.RequestException as e:
+            log.exception(e)
+
+
+def wh_updater(queue):
+    wh_threshold_timer = default_timer()
+    wh_over_threshold = False
+
+    # Set up one session to use for all requests.
+    # Requests to the same host will reuse the underlying TCP
+    # connection, giving a performance increase.
+    session = get_async_requests_session(
+        wh_retries,
+        wh_backoff_factor,
+        wh_concurrency)
+
+
+    # Prepare to send data per timed message frames instead of per object.
+    frame_interval_sec = (wh_frame_interval / 1000)
+    frame_first_message_time_sec = default_timer()
+    frame_messages = []
+    first_message = True
+
+    # How low do we want the queue size to stay?
+    wh_warning_threshold = 100
+    # How long can it be over the threshold, in seconds?
+    # Default: 5 seconds per 100 in threshold + frame_interval_sec.
+    wh_threshold_lifetime = int(5 * (wh_warning_threshold / 100.0))
+    wh_threshold_timer += frame_interval_sec
+
+    # The forever loop.
+    while True:
+        try:
+            # Loop the queue.
+            try:
+                timeout = frame_interval_sec if len(
+                    frame_messages) > 0 else None
+                whtype, message = queue.get(True, timeout)
+            except Empty:
+                pass
+            else:
+                for f in filters:           #Check filters that match
+                    if f.check(message):
+                        frame_message = {'webhook': f.get_webhook_url(), 'message': f.format_webhook(message)}
+                        frame_messages.append(frame_message)
+                queue.task_done()
+            # Store the time when we added the first message instead of the
+            # time when we last cleared the messages, so we more accurately
+            # measure time spent getting messages from our queue.
+            now = default_timer()
+            num_messages = len(frame_messages)
+
+            if num_messages == 1 and first_message:
+                frame_first_message_time_sec = now
+                first_message = False
+
+            # If enough time has passed, send the message frame.
+            time_passed_sec = now - frame_first_message_time_sec
+
+            if num_messages > 0 and (time_passed_sec >
+                                     frame_interval_sec):
+                log.debug('Sending %d items webhooks.',
+                          num_messages)
+                send_to_webhooks(session, frame_messages)
+
+                frame_messages = []
+                first_message = True
+
+            # Webhook queue moving too slow.
+            if (not wh_over_threshold) and (
+                    queue.qsize() > wh_warning_threshold):
+                wh_over_threshold = True
+                wh_threshold_timer = default_timer()
+            elif wh_over_threshold:
+                if queue.qsize() < wh_warning_threshold:
+                    wh_over_threshold = False
+                else:
+                    timediff_sec = default_timer() - wh_threshold_timer
+
+                    if timediff_sec > wh_threshold_lifetime:
+                        log.warning('Webhook queue has been > %d (@%d);'
+                                    + ' for over %d seconds,'
+                                    + ' try increasing --wh-threads.',
+                                    wh_warning_threshold,
+                                    queue.qsize(),
+                                    wh_threshold_lifetime)
+
+        except Exception as e:
+            log.exception('Exception in wh_updater: %s.', e)
+
+
+def load_webhook_template(file):
+    with open(file, 'r') as template:
+        temp = json.loads(template.read(), 'utf-8')
+        template.close()
+        return temp
+
+
+# Helpers
+# Background handler for completed webhook requests.
+def __wh_completed(sess, resp):
+    # Instantly close the response to release the connection back to the pool.
+    resp.close()
+
+
+# Get a future_requests FuturesSession that supports asynchronous workers
+# and retrying requests on failure.
+# Setting up a persistent session that is re-used by multiple requests can
+# speed up requests to the same host, as it'll re-use the underlying TCP
+# connection.
+def get_async_requests_session(num_retries, backoff_factor, pool_size,
+                               status_forcelist=None):
+    # Use requests & urllib3 to auto-retry.
+    # If the backoff_factor is 0.1, then sleep() will sleep for [0.1s, 0.2s,
+    # 0.4s, ...] between retries. It will also force a retry if the status
+    # code returned is in status_forcelist.
+    if status_forcelist is None:
+        status_forcelist = [500, 502, 503, 504]
+    session = FuturesSession(max_workers=pool_size)
+
+    # If any regular response is generated, no retry is done. Without using
+    # the status_forcelist, even a response with status 500 will not be
+    # retried.
+    retries = Retry(total=num_retries, backoff_factor=backoff_factor,
+                    status_forcelist=status_forcelist)
+
+    # Mount handler on both HTTP & HTTPS.
+    session.mount('http://', HTTPAdapter(max_retries=retries,
+                                         pool_connections=pool_size,
+                                         pool_maxsize=pool_size))
+    session.mount('https://', HTTPAdapter(max_retries=retries,
+                                          pool_connections=pool_size,
+                                          pool_maxsize=pool_size))
+
+    return session
+
+
+def load_filters(filter_file):
+
+    with open(filter_file, 'r') as f:
+        filt_file = json.loads(f.read(), 'utf-8')
+        f.close()
+        if type(filt_file) is not dict:
+            log.error("Filters must be a proper JSON file!")
+            return False
+        for filt_key in filt_file:
+            settings = filt_file[filt_key]
+            if 'webhook' in settings and 'filter' in settings:
+                filt = Filter(filt_key, settings)
+                check, msg = filt.validate()
+                if check:
+                    filters.append(filt)
+                    log.debug('Added filter %s', filt_key)
+                else:
+                    log.error(msg)
+                    return False
+            else:
+                log.error("Webhook filters must contain webhook and filter!")
+    log.debug("Successfully loaded %d filters.", len(filt_file))
+    return True
+
+
+class Filter:
+
+    def __init__(self, filt_name, filt_settings):
+        self.name = filt_name
+        if 'webhook' in filt_settings:
+            self.webhook = filt_settings.pop('webhook')
+        if 'filter' in filt_settings:
+            self.filter = filt_settings.pop('filter')
+        self.enabled = filt_settings.get('enabled', True)
+
+    def check(self, data):
+        if 'types' in self.filter:
+            if data.get('type') not in self.filter['types']:
+                return False
+        if 'min_lvl' in self.filter:
+            if data.get('level', 0) < self.filter['min_lvl']:
+                return False
+        if 'max_lvl' in self.filter:
+            if data.get('level', 1000) > self.filter['max_lvl']:
+                return False
+        if 'system_id' in self.filter:
+            if not data.get('system_id') or data.get('system_id') not in self.filter['system_id']:
+                return False
+
+        return True
+
+    def validate(self):
+        if not isinstance(self.webhook, dict):
+            return False, "Webhook must be a dict. Please refer to the example."
+        if not self.webhook.get('url') or not self.webhook.get('data'):
+            return False, "Webhook must have a url and data set!"
+        if not isinstance(self.filter, dict):
+            return False, "Filter must be a dict. Please refer to the example."
+        if 'types' in self.filter and not isinstance(self.filter['types'], list):
+            return False, "Filter types must be a list!"
+        if 'system_id' in self.filter and not isinstance(self.filter['system_id'], list):
+            return False, "Filter system_id must be a list!"
+        if 'min_lvl' in self.filter and not str(self.filter['min_lvl']).isdigit():
+            return False, "Filter min_lvl must be an integer!"
+        if 'max_lvl' in self.filter and not str(self.filter['max_lvl']).isdigit():
+            return False, "Filter max_lvl must be an integer!"
+        return True, ""
+
+    def get_webhook_url(self):
+        return self.webhook.get('url')
+
+    def format_webhook(self, data_in):
+        wh_data = copy.deepcopy(self.webhook.get('data', {}))
+        for key in wh_data:
+            for repl in data_in:
+                wh_data[key] = wh_data[key].replace('<{}>'.format(repl), str(data_in[repl]))
+        return wh_data
 

--- a/pgpool/webhook.py
+++ b/pgpool/webhook.py
@@ -193,13 +193,14 @@ def load_filters(filter_file):
             settings = filt_file[filt_key]
             if 'webhook' in settings and 'filter' in settings:
                 filt = Filter(filt_key, settings)
-                check, msg = filt.validate()
-                if check and filt.enabled:
-                    filters.append(filt)
-                    log.debug('Added filter %s', filt_key)
-                else:
-                    log.error(msg)
-                    return False
+                if filt.enabled:
+                    check, msg = filt.validate()
+                    if check:
+                        filters.append(filt)
+                        log.debug('Added filter %s', filt_key)
+                    else:
+                        log.error(msg)
+                        return False
             else:
                 log.error("Webhook filters must contain webhook and filter!")
     log.debug("Successfully loaded %d filters.", len(filt_file))

--- a/pgpool/webhook.py
+++ b/pgpool/webhook.py
@@ -194,7 +194,7 @@ def load_filters(filter_file):
             if 'webhook' in settings and 'filter' in settings:
                 filt = Filter(filt_key, settings)
                 check, msg = filt.validate()
-                if check:
+                if check and filt.enabled:
                     filters.append(filt)
                     log.debug('Added filter %s', filt_key)
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ peewee==2.8.1
 flask
 configargparse
 PyMySQL
+requests==2.13.0
+requests-futures==0.9.7

--- a/webhook_filter.json.example
+++ b/webhook_filter.json.example
@@ -19,7 +19,7 @@
             "url": "[WEBHOOK_URL_GOES_HERE]",
             "data": {
                 "username": "whatever you want",
-                "content": "These are the possible substitutions: <type>,<system_id>,<assigned_at>,<running_time>,<username>,<auth_service>,<latitude>,<longitude>,<level>,<xp>,<encounters>,<last_modified>,<warn>,<shadowbanned>,<banned>,<ban_flag>,<captcha>,<rareless_scans>,<message>,<good_low_level>,<good_high_level>,<good_total>"
+                "content": "These are the possible substitutions: <type>,<system_id>,<assigned_at>,<running_time>,<username>,<auth_service>,<latitude>,<longitude>,<level>,<xp>,<encounters>,<last_modified>,<warn>,<shadowbanned>,<banned>,<ban_flag>,<captcha>,<rareless_scans>,<message>,<good_low_level>,<good_high_level>,<good_total>",
                 "embed": "Set data to the parameters your webhook requires, all fields in data will have the above substitutions."
             }
         },

--- a/webhook_filter.json.example
+++ b/webhook_filter.json.example
@@ -27,7 +27,9 @@
             "types": ["assigned","levelup","warn","shadowban","ban","banflag","captcha","release"],
             "system_id": ["sys_id1", "sys_id2", "sys_id3"],
             "min_lvl": 1,
-            "max_lvl": 40
+            "max_lvl": 40,
+            "low_lvl_threshold": 100,
+            "high_lvl_threshold": 5
         }
     }
 }

--- a/webhook_filter.json.example
+++ b/webhook_filter.json.example
@@ -1,0 +1,33 @@
+{
+    "DISCORD_HIGH_LEVELS": {
+        "enabled": false,
+        "webhook": {
+            "url": "",
+            "data": {
+                "username": "PGPool",
+                "content": "[<system_id>] <username> (Level <level>): <message> after <running_time> hours."
+            }
+        },
+        "filter": {
+            "types": ["banned", "shadowbanned"],
+            "min_lvl": 30
+        }
+    },
+    "OTHER_FILTER_TEST": {
+        "enabled": false,
+        "webhook": {
+            "url": "[WEBHOOK_URL_GOES_HERE]",
+            "data": {
+                "username": "whatever you want",
+                "content": "These are the possible substitutions: <type>,<system_id>,<assigned_at>,<running_time>,<username>,<auth_service>,<latitude>,<longitude>,<level>,<xp>,<encounters>,<last_modified>,<warn>,<shadowbanned>,<banned>,<ban_flag>,<captcha>,<rareless_scans>,<message>,<good_low_level>,<good_high_level>,<good_total>"
+                "embed": "Set data to the parameters your webhook requires, all fields in data will have the above substitutions."
+            }
+        },
+        "filter": {
+            "types": ["assigned","levelup","warn","shadowban","ban","banflag","captcha","release"],
+            "system_id": ["sys_id1", "sys_id2", "sys_id3"],
+            "min_lvl": 1,
+            "max_lvl": 40
+        }
+    }
+}

--- a/webhook_filter.json.example
+++ b/webhook_filter.json.example
@@ -9,7 +9,7 @@
             }
         },
         "filter": {
-            "types": ["banned", "shadowbanned"],
+            "types": ["ban", "shadowban"],
             "min_lvl": 30
         }
     },
@@ -24,7 +24,7 @@
             }
         },
         "filter": {
-            "types": ["assigned","levelup","warn","shadowban","ban","banflag","captcha","release"],
+            "types": ["assign","levelup","warn","shadowban","ban","banflag","captcha","release"],
             "system_id": ["sys_id1", "sys_id2", "sys_id3"],
             "min_lvl": 1,
             "max_lvl": 40,


### PR DESCRIPTION
This adds Webhooks with Filtering to PGPool. This PR was based on code from RocketMap and PokeAlarm, so credit to the developers for their hard work.

Events that are logged by PGPool will also create a webhook that is filtered and sent in a separate thread. The webhook and filter are configured in a json file, see webhook_filter.json.example for the basic setup.

Two options are added to pgpool.config:

`'wh_filter': ''`   This is the webhook filter file
`'wh_threads': 1`   This specifies how many webhook threads should run.

This requires a small update to the database schema so a backup of your pgpool database should be done before testing. Also requires a new requirement (requests-futures==0.9.7) that is shared from RocketMap so most people shouldn't need to upgrade.

I recommend a `pip install -r requirements.txt` --upgrade anyways.